### PR TITLE
Tighten dependency version floors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,12 +20,12 @@ classifiers = [
 ]
 
 dependencies = [
-    "mcp>=1.0.0",
-    "lancedb>=0.4.0",
-    "pyarrow>=14.0.0",
+    "mcp>=1.20.0,<2",
+    "lancedb>=0.20.0",
+    "pyarrow>=14.0.1",
     "click>=8.0.0",
-    "sentence-transformers>=2.2.0",
-    "blessed>=1.20.0",
+    "sentence-transformers>=3.0.0",
+    "blessed>=1.21.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

- **lancedb** >=0.4.0 -> >=0.20.0: hybrid search, native FTS, and embedding registry APIs don't exist in 0.4.x. Installing oubli today could resolve a version that crashes on first search.
- **mcp** >=1.0.0 -> >=1.20.0,<2: FastMCP import unavailable in early 1.x releases. Cap <2 to avoid breaking changes.
- **sentence-transformers** >=2.2.0 -> >=3.0.0: transitive CVEs (CVE-2024-11392/93/94) via old transformers pulled by v2.x. v3.0+ pulls patched versions.
- **blessed** >=1.20.0 -> >=1.21.0: regression in 1.20.x release.
- **pyarrow** >=14.0.0 -> >=14.0.1: CVE-2023-47248 (supersedes PR #3).

No API changes required. All floors validated against actual import and usage patterns in the codebase.

## Test plan

- [ ] `uv pip install -e .` resolves successfully with tightened floors
- [ ] `oubli` CLI starts without import errors
- [ ] Existing tests pass (once CI is in place)

🤖 Generated with [Claude Code](https://claude.com/claude-code)